### PR TITLE
Dejar de seguir cambios en .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.gitignore
 notebooks/*


### PR DESCRIPTION
Hola a todos,

Trabajando en la tarea 1, git insistía en que agregara a mis commits los cambios personales que realicé en el archivo ``.gitignore``. Para evitar esto y para permitirle a cada quien elegir qué cosas rastrear o no independientemente de los cambios de .gitignore en upstream, propongo agregar ``.gitignore`` a las rutas ignoradas por git.

Saludos,
Gabriel.